### PR TITLE
Add twin monoclinic anisotropy interaction

### DIFF
--- a/examples/twin_monoclinic_anisotropy.jl
+++ b/examples/twin_monoclinic_anisotropy.jl
@@ -1,0 +1,63 @@
+using MicroMagnetic
+
+function vcross(u, v)
+    return (u[2] * v[3] - u[3] * v[2],
+            u[3] * v[1] - u[1] * v[3],
+            u[1] * v[2] - u[2] * v[1])
+end
+
+function vscale(a, u)
+    return (a * u[1], a * u[2], a * u[3])
+end
+
+function vnorm(u)
+    n = sqrt(u[1]^2 + u[2]^2 + u[3]^2)
+    return (u[1] / n, u[2] / n, u[3] / n)
+end
+
+function setup_twin_monoclinic_example()
+    mesh = FDMesh(; nx=160, ny=120, nz=6, dx=5e-9, dy=5e-9, dz=5e-9)
+    sim = Sim(mesh; driver="SD", name="twin_monoclinic_anisotropy")
+
+    Ms = 4.8e5
+    A = 1.2e-11
+    add_exch(sim, A)
+    add_demag(sim)
+    add_zeeman(sim, (0, 0, 1.0e4))
+
+    c_axis = (0.0, 0.0, 1.0)
+    b_left = vnorm((-1.0, 1.0, 0.0))
+    b_right = vnorm((1.0, 1.0, 0.0))
+    a_left = vnorm(vcross(b_left, c_axis))
+    a_right = vnorm(vcross(b_right, c_axis))
+
+    function axis_b_fun(x, y, z)
+        return x < 400e-9 ? b_left : b_right
+    end
+
+    function axis_a_fun(x, y, z)
+        return x < 400e-9 ? a_left : a_right
+    end
+
+    function axis_u111_fun(x, y, z)
+        a = x < 400e-9 ? a_left : a_right
+        return vnorm(vscale(sqrt(2 / 3), a) .+ vscale(1 / sqrt(3), c_axis))
+    end
+
+    set_Ms(sim, Ms)
+    add_twin_mono_anis(sim; Ka=0.0, Kb=2.0e4, Kaa=0.0, Kbb=1.3e4, Kab=0.0,
+                       Ku=8.0e3, axis_a=axis_a_fun, axis_b=axis_b_fun,
+                       axis_u111=axis_u111_fun)
+
+    function init_m(x, y, z)
+        phase = sin(2pi * y / 180e-9)
+        return phase > 0 ? (0.15, 0.1, 0.98) : (-0.15, -0.1, -0.98)
+    end
+
+    init_m0(sim, init_m)
+    relax(sim; max_steps=5000, stopping_dmdt=0.02)
+    save_vtk(sim, "twin_monoclinic_anisotropy")
+    return sim
+end
+
+setup_twin_monoclinic_example()

--- a/src/head.jl
+++ b/src/head.jl
@@ -201,6 +201,21 @@ mutable struct HexagonalAnisotropy{T<:AbstractFloat} <: MicroEnergy
     name::String
 end
 
+mutable struct TwinMonoclinicAnisotropy{T<:AbstractFloat} <: MicroEnergy
+    Ka::T
+    Kb::T
+    Kaa::T
+    Kbb::T
+    Kab::T
+    Ku::T
+    axis_a::AbstractArray{T,1}
+    axis_b::AbstractArray{T,1}
+    axis_u111::AbstractArray{T,1}
+    field::AbstractArray{T,1}
+    energy::AbstractArray{T,1}
+    name::String
+end
+
 mutable struct SpatialExchange{T<:AbstractFloat} <: MicroEnergy
     A::AbstractArray{T,1}
     field::AbstractArray{T,1}

--- a/src/micro/add_field.jl
+++ b/src/micro/add_field.jl
@@ -1,4 +1,5 @@
 export add_zeeman, update_zeeman, add_anis, update_anis, add_cubic_anis, add_hex_anis,
+       add_twin_mono_anis,
        add_exch, add_dmi, add_sahe_torque, add_demag, add_dmi_int, add_exch_int,
        add_thermal_noise, add_sot, add_stt, add_torque, rm_demag_charges
 
@@ -581,6 +582,62 @@ function add_hex_anis(sim::AbstractSim; K1=0, K2=0, K3=0, name="hex")
                         o::AbstractSim -> sum(anis.energy)))
     end
     @info "Hexagonal Anisotropy has been added."
+    send_sim_state(sim)
+    return anis
+end
+
+@doc raw"""
+    add_twin_mono_anis(sim::AbstractSim; Ka=0, Kb=0, Kaa=0, Kbb=0, Kab=0, Ku=0,
+                       axis_a=(1, 0, 0), axis_b=(0, 1, 0), axis_u111=(0, 0, 1),
+                       name="twin_mono_anis")
+
+Add a local monoclinic anisotropy whose crystallographic axes can vary in space, for
+example across Verwey twin domains.
+
+The energy density is defined as:
+
+```math
+E = K_a \alpha_a^2 + K_b \alpha_b^2 + K_{aa} \alpha_a^4
+  + K_{bb} \alpha_b^4 + K_{ab} \alpha_a^2 \alpha_b^2
+  - K_u \alpha_{111}^2
+```
+
+where ``\alpha_a = \mathbf{m}\cdot\mathbf{a}``,
+``\alpha_b = \mathbf{m}\cdot\mathbf{b}``, and
+``\alpha_{111} = \mathbf{m}\cdot\mathbf{u}_{111}``.
+"""
+function add_twin_mono_anis(sim::AbstractSim; Ka=0, Kb=0, Kaa=0, Kbb=0, Kab=0, Ku=0,
+                            axis_a::TupleOrArrayOrFunction=(1, 0, 0),
+                            axis_b::TupleOrArrayOrFunction=(0, 1, 0),
+                            axis_u111::TupleOrArrayOrFunction=(0, 0, 1),
+                            name="twin_mono_anis")
+    n_total = sim.n_total
+
+    T = Float[]
+    axes_a = zeros(T, 3 * n_total)
+    axes_b = zeros(T, 3 * n_total)
+    axes_u111 = zeros(T, 3 * n_total)
+
+    init_vector!(axes_a, sim.mesh, axis_a)
+    init_vector!(axes_b, sim.mesh, axis_b)
+    init_vector!(axes_u111, sim.mesh, axis_u111)
+    normalise(axes_a, n_total)
+    normalise(axes_b, n_total)
+    normalise(axes_u111, n_total)
+
+    anis = TwinMonoclinicAnisotropy(T(Ka), T(Kb), T(Kaa), T(Kbb), T(Kab), T(Ku),
+                                    kernel_array(axes_a), kernel_array(axes_b),
+                                    kernel_array(axes_u111), create_zeros(3 * n_total),
+                                    create_zeros(n_total), name)
+    push!(sim.interactions, anis)
+
+    if sim.save_data
+        push!(sim.saver.items,
+              SaverItem(string("E_", name), "<J>",
+                        o::AbstractSim -> sum(anis.energy)))
+    end
+
+    @info "Twin monoclinic anisotropy has been added."
     send_sim_state(sim)
     return anis
 end

--- a/src/micro/field.jl
+++ b/src/micro/field.jl
@@ -85,6 +85,19 @@ function effective_field(anis::HexagonalAnisotropy, sim::MicroSim, spin::Abstrac
     return nothing
 end
 
+function effective_field(anis::TwinMonoclinicAnisotropy, sim::MicroSim,
+                         spin::AbstractArray{T,1}, t::Float64) where {T<:AbstractFloat}
+    N = sim.n_total
+    volume = T(sim.mesh.volume)
+
+    twin_monoclinic_anisotropy_kernel!(default_backend[], groupsize[])(
+        spin, anis.field, anis.energy, anis.axis_a, anis.axis_b, anis.axis_u111,
+        sim.mu0_Ms, T(anis.Ka), T(anis.Kb), T(anis.Kaa), T(anis.Kbb),
+        T(anis.Kab), T(anis.Ku), volume; ndrange=N)
+
+    return nothing
+end
+
 function effective_field(exch::SpatialExchange, sim::MicroSim, spin::AbstractArray{T,1},
                          t::Float64) where {T<:AbstractFloat}
     n_total = sim.n_total

--- a/src/micro/kernels.jl
+++ b/src/micro/kernels.jl
@@ -168,6 +168,63 @@ The kernel hexagonal_anisotropy_kernel! works for both the micromagnetic and ato
     end
 end
 
+@kernel function twin_monoclinic_anisotropy_kernel!(@Const(m), h, energy,
+                                                    @Const(axis_a), @Const(axis_b),
+                                                    @Const(axis_u111), @Const(mu0_Ms),
+                                                    Ka::T, Kb::T, Kaa::T, Kbb::T,
+                                                    Kab::T, Ku::T,
+                                                    volume::T) where {T<:AbstractFloat}
+    id = @index(Global)
+    j = 3 * (id - 1)
+
+    @inbounds Ms_local = mu0_Ms[id]
+
+    if Ms_local == T(0)
+        @inbounds energy[id] = 0
+        @inbounds h[j + 1] = 0
+        @inbounds h[j + 2] = 0
+        @inbounds h[j + 3] = 0
+    else
+        @inbounds mx = m[j + 1]
+        @inbounds my = m[j + 2]
+        @inbounds mz = m[j + 3]
+
+        @inbounds ax = axis_a[j + 1]
+        @inbounds ay = axis_a[j + 2]
+        @inbounds az = axis_a[j + 3]
+        @inbounds bx = axis_b[j + 1]
+        @inbounds by = axis_b[j + 2]
+        @inbounds bz = axis_b[j + 3]
+        @inbounds ux = axis_u111[j + 1]
+        @inbounds uy = axis_u111[j + 2]
+        @inbounds uz = axis_u111[j + 3]
+
+        alpha_a = mx * ax + my * ay + mz * az
+        alpha_b = mx * bx + my * by + mz * bz
+        alpha_u = mx * ux + my * uy + mz * uz
+
+        alpha_a2 = alpha_a * alpha_a
+        alpha_b2 = alpha_b * alpha_b
+
+        dE_da = 2 * Ka * alpha_a + 4 * Kaa * alpha_a2 * alpha_a +
+                2 * Kab * alpha_a * alpha_b2
+        dE_db = 2 * Kb * alpha_b + 4 * Kbb * alpha_b2 * alpha_b +
+                2 * Kab * alpha_b * alpha_a2
+        dE_du = -2 * Ku * alpha_u
+
+        Ms_inv::T = 1 / Ms_local
+        @inbounds h[j + 1] = -Ms_inv * (dE_da * ax + dE_db * bx + dE_du * ux)
+        @inbounds h[j + 2] = -Ms_inv * (dE_da * ay + dE_db * by + dE_du * uy)
+        @inbounds h[j + 3] = -Ms_inv * (dE_da * az + dE_db * bz + dE_du * uz)
+
+        @inbounds energy[id] = (Ka * alpha_a2 + Kb * alpha_b2 +
+                                Kaa * alpha_a2 * alpha_a2 +
+                                Kbb * alpha_b2 * alpha_b2 +
+                                Kab * alpha_a2 * alpha_b2 -
+                                Ku * alpha_u * alpha_u) * volume
+    end
+end
+
 @kernel function exchange_kernel!(@Const(m), h, energy, @Const(mu0_Ms), @Const(A), dx::T,
                                   dy::T, dz::T, @Const(ngbs),
                                   volume::T) where {T<:AbstractFloat}


### PR DESCRIPTION
This PR adds a spatially varying twin monoclinic anisotropy interaction for micromagnetic simulations.

The new interaction supports local monoclinic axes across twin domains and uses the energy density:

E = Ka*a^2 + Kb*b^2 + Kaa*a^4 + Kbb*b^4 + Kab*a^2*b^2 - Ku*u111^2

where a, b, and u111 are local crystallographic axes. An example script is included to demonstrate a two-domain twin configuration.